### PR TITLE
Update Textfield

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+TODO
+
+ - *.on* -> Options.on*
+ - Textfield now `Textfield.render Mdl [0] model.mdl [] []`
+   (note last argument)
+ - Textfield.inner -> Options.input
+

--- a/demo/Demo/Menus.elm
+++ b/demo/Demo/Menus.elm
@@ -426,8 +426,9 @@ view model =
                   , model.icon 
                       |> Maybe.withDefault ""
                       |> Textfield.value
-                  , Textfield.onInput SetIcon
+                  , Options.onInput SetIcon
                   ]
+                  []
               , Options.styled p [ css "margin-top" "1rem" ] 
                   [ text "Try 'list' or 'menu', or refer to " 
                   , a [ href "https://design.google.com/icons/" ]

--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -32,7 +32,6 @@ model =
 type Msg
   = Slider Int Float
   | Mdl (Material.Msg Msg)
-  | NoOp String
 
 
 get : Int -> Dict Int Float -> Float
@@ -48,10 +47,6 @@ getDef key def dict =
 update : Msg -> Model -> (Model, Cmd Msg)
 update action model =
   case action of
-    NoOp msg ->
-      let _ = Debug.log "NoOp" msg
-      in (model, Cmd.none)
-
     Slider idx value ->
       let
         values = Dict.insert idx value model.values
@@ -84,8 +79,6 @@ view model  =
       , demoContainer
           ( Slider.view
               [ Slider.onChange (Slider 0)
-              , Options.dispatch Mdl
-              , Options.inner [ Options.on1 "change" (NoOp <| toString (Slider 0 0)) ]
               , Slider.value (getDef 0 50.0 model.values)
               ]
           ,

--- a/demo/elm-package.json
+++ b/demo/elm-package.json
@@ -18,7 +18,8 @@
         "elm-lang/window": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
         "evancz/elm-markdown": "3.0.0 <= v < 4.0.0",
-        "rgrempel/elm-route-url": "2.0.0 <= v < 3.0.0"
+        "rgrempel/elm-route-url": "2.0.0 <= v < 3.0.0",
+        "elm-lang/dom": "1.1.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.18.0"
 }

--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -59,10 +59,8 @@ for details about what type of buttons are appropriate for which situations.
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
---import Html.Events
 import Html.App
 import Platform.Cmd exposing (Cmd, none)
-
 
 import Parts exposing (Indexed, Index)
 
@@ -70,18 +68,19 @@ import Material.Helpers as Helpers
 import Material.Options.Internal as Internal
 import Material.Options as Options exposing (cs, when)
 import Material.Ripple as Ripple
-
 import Material.Msg as Msg
+
 
 -- MODEL
 
 
-{-|
+{-| 
 -}
-type alias Model = Ripple.Model
+type alias Model = 
+  Ripple.Model
 
 
-{-|
+{-| 
 -}
 defaultModel : Model
 defaultModel =
@@ -91,7 +90,7 @@ defaultModel =
 -- ACTION, UPDATE
 
 
-{-| Component action.
+{-| 
 -}
 type alias Msg
   = Ripple.Msg
@@ -386,15 +385,20 @@ type alias Container c =
   { c | button : Indexed Model }
 
 
+set : Indexed Model -> Container c -> Container c
+set x y = 
+  { y | button = x }
+
+
 {-| Component render.  Below is an example, assuming boilerplate setup as
-indicated in `Material`, and a user message `PollMsg`.
+indicated in `Material` and a user message `PollMsg`.
 
     Button.render Mdl [0] model.mdl
       [ Button.raised
       , Button.ripple
       , Options.onClick PollMsg
       ]
-      [ text "Fetch new"]
+      [ text "Fetch new" ]
 -}
 render
   : (Msg.Msg (Container c) m -> m)
@@ -404,5 +408,9 @@ render
   -> List (Html m)
   -> Html m
 render lift =
-  Parts.create (Internal.inject view lift) (Parts.generalize update) .button (\x y -> {y | button=x}) Ripple.model
+  Parts.create 
+    (Internal.inject view lift) 
+    (Parts.generalize update) 
+    .button set
+    Ripple.model
     (Msg.Internal >> lift)

--- a/src/Material/Options/Internal.elm
+++ b/src/Material/Options/Internal.elm
@@ -55,8 +55,8 @@ inject
     -> List (Property d e)
     -> f
     -> g
-inject viewFun lift =
-  \a b c d -> viewFun a b (dispatch lift :: c) d
+inject view lift a b c =
+  view a b (dispatch lift :: c)
 
 
 {-| Inject dispatch
@@ -69,5 +69,5 @@ inject'
     -> List (Property { f | inner : List (Property d e) } e)
     -> g
     -> h
-inject' viewFun lift =
-  \a b c d -> viewFun a b (inner [ dispatch lift ] :: dispatch lift :: c) d
+inject' view lift a b c =
+  view a b (inner [ dispatch lift ] :: dispatch lift :: c)


### PR DESCRIPTION
I updated Textfield to conform to our discussions on Slack. I think the outcome is rather nice: We keep (mostly) the old API, breaking as few things as possible, but you now have custom events and can add attributes freely. 
